### PR TITLE
Drop support ruby 2.3 and 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,12 +83,6 @@ jobs:
 
 build_jobs: &build_jobs
   - rspec:
-      name:    "rspec:2.3"
-      version: "2.3"
-  - rspec:
-      name:    "rspec:2.4"
-      version: "2.4"
-  - rspec:
       name:    "rspec:2.5"
       version: "2.5"
   - rspec:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
     parameters:
       tag:
         type: string
-        default: "latest"
+        default: "2.6"
     docker:
       - image: ruby:<< parameters.tag >>
     environment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_gem:
     - "config/rspec.yml"
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   # uncomment if use rails cops
   # TargetRailsVersion: 5.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,3 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in itest5ch.gemspec
 gemspec
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.5.0")
-  # activesupport v6.0.0 requires Ruby v2.5.0+
-  gem "activesupport", "< 6.0.0", group: :test
-end

--- a/itest5ch.gemspec
+++ b/itest5ch.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.5.0"
+
   spec.add_dependency "hpricot"
   spec.add_dependency "htmlentities"
 


### PR DESCRIPTION
`URI.open` requires ruby 2.5+

c.f. https://circleci.com/gh/sue445/itest5ch/913