### PR TITLE
Fix RangeError invalid codepoint in UTF-8 when htmlentities 4.4.0+

### DIFF
--- a/lib/itest5ch/thread.rb
+++ b/lib/itest5ch/thread.rb
@@ -82,7 +82,14 @@ module Itest5ch
     #
     # @return [String]
     def self.normalize_message(message)
-      message = coder.decode(message).scrub("")
+      message =
+        begin
+          coder.decode(message)
+        rescue RangeError
+          message.gsub(/&#\d+;/, "")
+        end
+      message = message.scrub("")
+
       message = CGI.unescapeHTML(message)
       message.gsub(/\s*<br>\s*/i, "\n").strip
     end


### PR DESCRIPTION
```
  1) Itest5ch::Thread.normalize_message with invalid character
     Failure/Error: message = coder.decode(message).scrub("")

     RangeError:
       invalid codepoint 0xD83D in UTF-8
```

This behavior has been changed since https://github.com/threedaymonk/htmlentities/commit/049ec3b63c2fcc86fc58ca6e65310482be5a0891

Close #114