### PR TITLE
Revert "Workaround for error in rspec-parameterized-table_syntax"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,3 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in itest5ch.gemspec
 gemspec
-
-# FIXME: Workaround for Ruby 4.0+
-# ref. https://github.com/banister/binding_of_caller/pull/90
-gem "binding_of_caller", github: "kivikakk/binding_of_caller", branch: "push-yrnnzolypxun"


### PR DESCRIPTION
This reverts commit 1ac893ca95e4e2e0be04fc6fcdeca9dcac8e0760.